### PR TITLE
Fix SQL column name escaping

### DIFF
--- a/include/warehouse_ros_sqlite/utils.hpp
+++ b/include/warehouse_ros_sqlite/utils.hpp
@@ -104,7 +104,7 @@ using escaped_columnname = std::string;
 using escaped_tablename = std::string;
 inline std::string escape_identifier(const std::string & s)
 {
-  return "\"" + detail::escape<'"'>(s) + "\"";
+  return "`" + detail::escape<'`'>(s) + "`";
 }
 inline escaped_columnname escape_columnname_with_prefix(const std::string & c)
 {

--- a/test/DatabaseConnection.cpp
+++ b/test/DatabaseConnection.cpp
@@ -30,6 +30,7 @@
 
 #include <gtest/gtest.h>
 
+#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <warehouse_ros_sqlite/database_connection.hpp>
@@ -400,6 +401,41 @@ TEST_F(ConnectionTest, Sorting)
     ASSERT_EQ(list1.size(), size_t(2));
     EXPECT_EQ(list1[0]->lookupInt("x"), 71);
     EXPECT_EQ(list1[1]->lookupInt("x"), 10);
+  }
+}
+
+TEST_F(ConnectionTest, appendGTE)
+{
+  auto coll = conn_->openCollection<geometry_msgs::msg::Point>("test_db", "test_collection");
+
+  auto metadata = coll.createMetadata();
+  metadata->append("test_metadata", 5.0);
+
+  geometry_msgs::msg::Point msg = {};
+  coll.insert(msg, metadata);
+
+  {
+    auto query = coll.createQuery();
+    query->appendGTE("unrelated", 4.0);
+    EXPECT_TRUE(coll.queryList(query).empty());
+  }
+
+  {
+    auto query = coll.createQuery();
+    query->appendGT("unrelated", 4.0);
+    EXPECT_TRUE(coll.queryList(query).empty());
+  }
+
+  {
+    auto query = coll.createQuery();
+    query->appendLTE("unrelated", 6.0);
+    EXPECT_TRUE(coll.queryList(query).empty());
+  }
+
+  {
+    auto query = coll.createQuery();
+    query->appendLT("unrelated", 6.0);
+    EXPECT_TRUE(coll.queryList(query).empty());
   }
 }
 

--- a/test/DatabaseConnection.cpp
+++ b/test/DatabaseConnection.cpp
@@ -439,6 +439,23 @@ TEST_F(ConnectionTest, appendGTE)
   }
 }
 
+TEST_F(ConnectionTest, BacktickInMeta)
+{
+  auto coll = conn_->openCollection<geometry_msgs::msg::Point>("test_db", "test_backtick");
+
+  auto metadata = coll.createMetadata();
+  metadata->append("test_`metadata", 5.0);
+
+  geometry_msgs::msg::Point msg = {};
+  coll.insert(msg, metadata);
+
+  {
+    auto query = coll.createQuery();
+    query->appendGTE("test_`metadata", 4.0);
+    EXPECT_EQ(coll.queryList(query).size(), 1);
+  }
+}
+
 TEST(Utils, Md5Validation)
 {
   const char * a = "4a842b65f413084dc2b10fb484ea7f17";


### PR DESCRIPTION
Using double quotes had the disadvantage that unknown
column names were silently changed to a string literal
in WHERE statements. This can be avoided by using backticks.


Can I ask someone with a ROS2 toolchain to test this PR? And to make a new release (1.0.4)?
Fixes #43
