### PR TITLE
Fix package dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,15 +12,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>sqlite3_vendor</build_depend>
   <build_depend>boost</build_depend>
-  <build_depend>libsqlite3-dev</build_depend>
 
   <depend>warehouse_ros</depend>
   <depend>class_loader</depend>
   <depend>rclcpp</depend>
-
-  <exec_depend>sqlite3</exec_depend>
+  <depend>sqlite3_vendor</depend>
 
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Depend on `sqlite3_vendor`, but not `SQLite3` and `libsqlite3-dev`.
Fixes #50.