### PR TITLE
Fix cmake deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(warehouse_ros_sqlite VERSION 1.0.1)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
ros_sqlite use ros_warehouse with cmake_minimum_required(VERSION 3.16.3)

this patch also fix cmake <3.10 deprecation
--
https://github.com/moveit/warehouse_ros/blob/ros2/CMakeLists.txt