### PR TITLE
Remove 'system' component from Boost package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(SQLite3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem system thread)
+find_package(Boost REQUIRED COMPONENTS filesystem thread)
 find_package(class_loader REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
With having system in the required components, this raises an error on ubuntu Resolute:

```
00:00:54 CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Boost-1.90.0/BoostConfig.cmake:141 (find_package):
00:00:54   Could not find a package configuration file provided by "boost_system"
00:00:54   (requested version 1.90.0) with any of the following names:
00:00:54 
00:00:54     boost_systemConfig.cmake
00:00:54     boost_system-config.cmake
```

Ubuntu Resolute ships boost 1.90. According to the [1.89 release notes](https://www.boost.org/releases/1.89.0/) the component has been dropped, mentioning that exact cmake issue. The solution should be to simply remove the component from the list. This should be backwards compatible down to boost 1.69, where ubuntu 22.04 (for ROS Humble) uses 1.74, so it should be fine to simply remove it.