### PR TITLE
Use explicit Boost targets in warehouse_ros_sqlite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CUR
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
 
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC
   Boost::headers
   class_loader::class_loader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC
+  Boost::headers
   class_loader::class_loader
   rclcpp::rclcpp
   warehouse_ros::warehouse_ros
@@ -64,12 +65,10 @@ if(BUILD_TESTING)
   target_link_libraries(SchemaVersion ${PROJECT_NAME})
 
   ament_add_gtest(TestLoader test/TestLoader.cpp)
-  target_link_libraries(TestLoader ${PROJECT_NAME})
-  target_link_libraries(TestLoader ${Boost_LIBRARIES})
+  target_link_libraries(TestLoader ${PROJECT_NAME} Boost::filesystem Boost::thread)
 
   ament_add_gtest(BusyHandler test/BusyHandler.cpp)
-  target_link_libraries(BusyHandler ${PROJECT_NAME})
-  target_link_libraries(BusyHandler ${Boost_LIBRARIES})
+  target_link_libraries(BusyHandler ${PROJECT_NAME} Boost::filesystem Boost::thread)
 
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-warehouse-ros-sqlite.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: warehouse_ros_sqlite only needs Boost headers for the library itself and filesystem/thread for the tests. Linking the explicit Boost targets avoids relying on the aggregate `${Boost_LIBRARIES}` variable and keeps the target dependencies precise for modern CMake toolchains.