### PR TITLE
ci: unblock and broaden the ros2 matrix for Rolling/Resolute

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,17 +13,27 @@ on:
 jobs:
   industrial_ci:
     strategy:
+      # Without this, one job failing for environmental reasons cancels every
+      # sibling before it can report, and the matrix yields no signal at all.
+      fail-fast: false
       matrix:
         env:
-          - {ROS_DISTRO: rolling, ROS_REPO: main, CCOV_UPLOAD: true,
+          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main, CCOV_UPLOAD: false}
+          - {ROS_DISTRO: kilted, ROS_REPO: main, CCOV_UPLOAD: false}
+          # lyrical and rolling are both Ubuntu Resolute. lyrical gates: it is
+          # released and ros-lyrical-warehouse-ros is published, so it gives a
+          # blocking Resolute signal. rolling cannot pass until
+          # ros-rolling-warehouse-ros is published, so it stays non-blocking;
+          # drop NONBLOCKING once it is.
+          - {ROS_DISTRO: lyrical, ROS_REPO: main, OS_CODE_NAME: resolute,
+             CCOV_UPLOAD: false}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing, OS_CODE_NAME: resolute,
+             NONBLOCKING: true, CCOV_UPLOAD: true,
              CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'",
              AFTER_RUN_TARGET_TEST: './.ci.prepare_codecov',
              ADDITIONAL_DEBS: 'curl lcov grep'}
-          - {ROS_DISTRO: rolling, ROS_REPO: testing, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: iron, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: iron, ROS_REPO: testing, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: main, CCOV_UPLOAD: false}
-          - {ROS_DISTRO: humble, ROS_REPO: testing, CCOV_UPLOAD: false}
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work
@@ -31,6 +41,7 @@ jobs:
 
     name: ${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}${{ matrix.env.CCOV_UPLOAD && ' + ccov' || ''}}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.env.NONBLOCKING || false }}
     steps:
       - uses: actions/checkout@v6
       # The target directory cache doesn't include the source directory because


### PR DESCRIPTION
The `ros2` matrix currently produces **no signal at all**, tests a distro this package is not released to, and omits three that it is.

### 1. `fail-fast` discards every result

The `strategy:` block has no `fail-fast: false`, so it defaults to `true`. The `rolling-main` job fails in ~60s for an environmental reason (below), and GitHub then cancels every sibling before it can report. From the latest run on `ros2` (`5e2fd13`, run 29725301361):

```
rolling-main + ccov  07:39:31 -> 07:40:39  failure
rolling-testing      07:39:31 -> 07:40:47  cancelled
humble-main          07:39:31 -> 07:40:47  cancelled
humble-testing       07:39:32 -> 07:40:47  cancelled
iron-main            07:39:31 -> 07:40:47  cancelled
iron-testing         07:39:31 -> 07:40:46  cancelled
```

One environmental failure, five results thrown away — including the two humble jobs that would have passed. **The consequence is that `#62` ("Use Boost targets"), the only commit on this branch since 1.0.8, has never been validated by CI.**

### 2. `rolling` + `ROS_REPO: main` cannot work on Ubuntu Resolute

Rolling's base OS moved to Resolute, and Rolling's `main` apt repo has no Resolute packages yet, so the job dies in setup, well before CMake:

```
E: Unable to locate package ros-rolling-ros-environment
'setup_rosdep' returned with code '100' after 0 min 8 sec
```

Switch it to `ROS_REPO: testing`, which does work on Resolute, and pin `OS_CODE_NAME: resolute` explicitly rather than relying on industrial_ci's default — that default has already changed once.

### 3. `iron` is EOL, and this package is not released to it

Both `iron` jobs go. Iron reached EOL in November 2024, and `iron/distribution.yaml` carries no `release:` version for `warehouse_ros_sqlite` — so a third of the matrix was testing a distro that never ships.

### 4. Three released distros had no coverage

Released from this single `ros2` branch, versus what was tested before this PR:

| distro | released | had CI |
|---|---|---|
| humble | 1.0.8-1 | ✅ |
| jazzy | 1.0.8-1 | ❌ |
| kilted | 1.0.8-1 | ❌ |
| lyrical | 1.0.8-1 | ❌ |
| rolling | 1.0.8-2 | ✅ (broken) |

### Resulting matrix

| job | base OS | blocking |
|---|---|---|
| `humble-main` | jammy | ✅ |
| `humble-testing` | jammy | ✅ |
| `jazzy-main` | noble | ✅ |
| `kilted-main` | noble | ✅ |
| `lyrical-main` | resolute | ✅ |
| `rolling-testing + ccov` | resolute | ✗ |

Coverage moves from the deleted `rolling-main` job onto `rolling-testing`, so it is non-blocking — the same trade [PickNikRobotics/rviz_visual_tools#301](https://github.com/PickNikRobotics/rviz_visual_tools/pull/301) made.

**lyrical gates.** It is released, it is Resolute, and `ros-lyrical-warehouse-ros` *is* published, so it provides a blocking Resolute signal instead of leaving all Resolute coverage on the non-blocking rolling job. Verified green on this branch.

**rolling stays non-blocking** because `ros-rolling-warehouse-ros` is not published:

```
E: Unable to locate package ros-rolling-warehouse-ros
'install_target_dependencies' returned with code '1' after 0 min 28 sec
```

`warehouse_ros` 2.0.7 is being released now with the `tf2` `.h` → `.hpp` fix that unblocks that build. **Drop `NONBLOCKING` from the rolling entry once it is on the buildfarm.**

### Result on this branch

| job | result |
|---|---|
| `humble-main` | ✅ |
| `humble-testing` | ✅ |
| `jazzy-main` | ✅ |
| `kilted-main` | ✅ |
| `lyrical-main` | ✅ |
| `rolling-testing + ccov` | ❌ (non-blocking, `ros-rolling-warehouse-ros`) |

Overall run conclusion is `success`. This is also the first time `#62` has been validated by CI — on five distros.

### ⚠️ Merging this requires a branch-protection update

Required status checks on `ros2` are currently:

```
["rolling-testing", "rolling-main + ccov", "humble-main", "humble-testing", "Format"]
```

This PR deletes `rolling-main + ccov` and renames `rolling-testing` to `rolling-testing + ccov`, so **two required checks will never report and the PR cannot merge** until protection is updated. Suggested new set, excluding only the intentionally non-blocking rolling job:

```
Format, humble-main, humble-testing, jazzy-main, kilted-main, lyrical-main
```

Use the scoped endpoint rather than a full protection `PUT`, which requires the whole object and silently drops anything omitted:

```bash
gh api -X PATCH repos/moveit/warehouse_ros_sqlite/branches/ros2/protection/required_status_checks \
  -F strict=true -f 'contexts[]=Format' -f 'contexts[]=humble-main' \
  -f 'contexts[]=humble-testing' -f 'contexts[]=jazzy-main' -f 'contexts[]=kilted-main' \
  -f 'contexts[]=lyrical-main'
```

### Noted but not changed

`prepare target_ws for cache` is gated on `! matrix.env.CCOV`, but the matrix defines `CCOV_UPLOAD`, never `CCOV` — so that condition is always true and the step also runs for the coverage job, whose `target_ws` is deliberately not cached. Harmless, pre-dates this PR, and left alone to keep this diff to the matrix.
